### PR TITLE
Update base Docker image to Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
-FROM node:5.1.1
+FROM risingstack/alpine:3.3-v5.7.0-3.1.0
 ENV PORT 5000
 EXPOSE 5000
 
-# Run app as a custom user `app`
 WORKDIR /app
-RUN useradd -m -d /app app
 # Run install first to cache the step
 ADD package.json /app/package.json
 RUN npm install --production
 ADD . /app
 
-RUN chown -R app.app /app
-
-USER app
 ENV HOME /app
 
 # Default command to run service


### PR DESCRIPTION
In this PR we change the base Docker image. Now we're using Alpine Linux under the hood, which is way more lightweight.

What | Before | After | %
--- | --- | --- | ---
Base Linux Image | Ubuntu | Alpine
Base image + Node env size | 641.8 MB | 253.3 MB | ~40%
Slack Cutter image size | 775.6 MB | 338.5 MB | ~44%

That means:
- Less storage usage
- Less internet bandwidth usage
- More speed in
  - Building Slack Cutter's image
  - Downloading these images from a Registry
  - Publishing the image in a Registry
  - Booting and execution of Slack Cutter